### PR TITLE
Implement issues #1-4 and geometry builders (#5a)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -182,6 +182,81 @@ var result = new SimulationEngine().Run(parameters);
 
 Custom materials can be added via `MaterialRegistry.Register(material)`.
 
+## Ohmic IR Drop Correction
+
+Set `PathLength` (metres) in `SimulationParameters` to model the ohmic resistance of the electrolyte path. When non-zero, a solution resistance `Rs = PathLength / κ` (Ω·m²) is computed at each step and the effective overpotential driving each electrode reaction is reduced accordingly.
+
+```csharp
+var parameters = new SimulationParameters(
+    new GalvanicPair(MaterialRegistry.Zinc, MaterialRegistry.Copper),
+    new AtmosphericConditions(25.0, 0.80, 0.1),
+    DurationSeconds: 86400,
+    TimeSteps: 1000,
+    PathLength: 0.005);        // 5 mm electrolyte path
+```
+
+## Spatial Current-Density Distribution
+
+Supply a `GeometryMesh` via `SimulationParameters.Mesh` to activate the 2-D Laplace solver. After the time-integration loop completes, the engine solves ∇²φ = 0 on the mesh and computes the nodal current density and corrosion rate from Faraday's law. Results are stored in `SimulationResult.NodalPotentials` and `SimulationResult.NodalCorrosionRates`.
+
+```csharp
+var geometry = new SideBySideGeometry(
+    MaterialRegistry.Zinc, MaterialRegistry.Copper,
+    anodeWidth: 0.020, cathodeWidth: 0.020, length: 0.050);
+
+var parameters = new SimulationParameters(
+    new GalvanicPair(MaterialRegistry.Zinc, MaterialRegistry.Copper),
+    new AtmosphericConditions(25.0, 0.80, 0.1),
+    DurationSeconds: 3600,
+    TimeSteps: 100,
+    Mesh: geometry.BuildMesh(20, 20));
+
+var result = new SimulationEngine().Run(parameters);
+// result.NodalPotentials     — V vs. SHE, flattened row-major
+// result.NodalCorrosionRates — mm/year, flattened row-major
+```
+
+## Species Transport Tracking
+
+Construct one or more `SpeciesTransport` objects and pass them in the `TrackedSpecies` list. At each simulation step the species concentration profiles are advanced by one diffusion step and the spatially-averaged concentration is written to `SimulationResult.SpeciesConcentrationHistory`.
+
+```csharp
+var chloride = new Species("Cl-", -1, diffusionCoefficient: 2.03e-9, concentration: 100.0);
+var transport = new SpeciesTransport(
+    chloride,
+    domainLength: 1e-4, gridPoints: 20,
+    initialProfile: Enumerable.Repeat(100.0, 20).ToArray(),
+    leftBC:  new DirichletBC(100.0),
+    rightBC: new DirichletBC(0.0),
+    timeStep: 36.0);
+
+var parameters = new SimulationParameters(
+    new GalvanicPair(MaterialRegistry.Zinc, MaterialRegistry.Copper),
+    new AtmosphericConditions(25.0, 0.80, 0.1),
+    DurationSeconds: 3600,
+    TimeSteps: 100,
+    TrackedSpecies: [transport]);
+
+var result = new SimulationEngine().Run(parameters);
+// result.SpeciesConcentrationHistory["Cl-"] — one entry per time point
+```
+
+## pH Evolution Tracking
+
+Set `TrackpH = true` in `SimulationParameters` to enable pH tracking. The engine uses the net anodic current density at each step as a proxy for proton production and updates the bulk pH accordingly. Results are available in `SimulationResult.pHHistory`.
+
+```csharp
+var parameters = new SimulationParameters(
+    new GalvanicPair(MaterialRegistry.Zinc, MaterialRegistry.Copper),
+    new AtmosphericConditions(25.0, 0.80, 0.1),
+    DurationSeconds: 86400,
+    TimeSteps: 1000,
+    TrackpH: true);
+
+var result = new SimulationEngine().Run(parameters);
+// result.pHHistory — one entry per time point
+```
+
 ## Next Steps
 
 - Read [ARCHITECTURE.md](ARCHITECTURE.md) for an overview of the library design

--- a/src/GCE.Electrochemistry/HydrogenEvolutionReaction.cs
+++ b/src/GCE.Electrochemistry/HydrogenEvolutionReaction.cs
@@ -91,4 +91,18 @@ public sealed class HydrogenEvolutionReaction : IElectrochemicalReaction
         double eta = potential - EquilibriumPotential;
         return _kinetics.CurrentDensity(eta);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="HydrogenEvolutionReaction"/> with the same kinetic parameters
+    /// but a different pH value (for step-by-step pH evolution).
+    /// </summary>
+    /// <param name="newpH">The updated pH value.</param>
+    public HydrogenEvolutionReaction WithpH(double newpH) =>
+        new(_kinetics.ExchangeCurrentDensity,
+            newpH,
+            HydrogenPartialPressure,
+            _kinetics.AnodicTransferCoefficient,
+            _kinetics.CathodicTransferCoefficient,
+            _kinetics.TemperatureKelvin,
+            _kinetics.LimitingCurrentDensity);
 }

--- a/src/GCE.Electrochemistry/OxygenReductionReaction.cs
+++ b/src/GCE.Electrochemistry/OxygenReductionReaction.cs
@@ -113,4 +113,19 @@ public sealed class OxygenReductionReaction : IElectrochemicalReaction
         double eta = potential - EquilibriumPotential;
         return _kinetics.CurrentDensity(eta);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="OxygenReductionReaction"/> with the same kinetic parameters
+    /// but a different pH value (for step-by-step pH evolution).
+    /// </summary>
+    /// <param name="newpH">The updated pH value.</param>
+    public OxygenReductionReaction WithpH(double newpH) =>
+        new(_kinetics.ExchangeCurrentDensity,
+            newpH,
+            OxygenPartialPressure,
+            Pathway,
+            _kinetics.AnodicTransferCoefficient,
+            _kinetics.CathodicTransferCoefficient,
+            _kinetics.TemperatureKelvin,
+            _kinetics.LimitingCurrentDensity);
 }

--- a/src/GCE.IO/VtkResultWriter.cs
+++ b/src/GCE.IO/VtkResultWriter.cs
@@ -89,6 +89,10 @@ public sealed class VtkResultWriter : IResultWriter
         {
             writer.WriteLine("      <PointData>");
             WriteRegionArray(writer, _mesh, indent: 8);
+            if (result.NodalPotentials is { Length: > 0 })
+                WriteDataArray(writer, "NodalPotential_V",           result.NodalPotentials,     indent: 8);
+            if (result.NodalCorrosionRates is { Length: > 0 })
+                WriteDataArray(writer, "NodalCorrosionRate_mmPerYear", result.NodalCorrosionRates, indent: 8);
             writer.WriteLine("      </PointData>");
         }
 

--- a/src/GCE.Simulation/Geometry/CoaxialCylinderGeometry.cs
+++ b/src/GCE.Simulation/Geometry/CoaxialCylinderGeometry.cs
@@ -1,0 +1,156 @@
+using GCE.Core;
+using GCE.Electrochemistry;
+
+namespace GCE.Simulation.Geometry;
+
+/// <summary>
+/// Geometry builder for a coaxial cylinder configuration: an inner cylinder of one
+/// material enclosed within an outer coaxial cylinder of a dissimilar material,
+/// with the annular gap filled by electrolyte.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Electrode areas are computed as lateral cylindrical surfaces:
+/// <list type="bullet">
+///   <item>
+///     <description>Inner area = 2π × <see cref="InnerRadius"/> × <see cref="Length"/>.</description>
+///   </item>
+///   <item>
+///     <description>Outer area = 2π × <see cref="OuterRadius"/> × <see cref="Length"/>.</description>
+///   </item>
+/// </list>
+/// </para>
+/// <para>
+/// The material with the lower standard potential is assigned as the anode; the
+/// other becomes the cathode.
+/// </para>
+/// <para>
+/// The 2-D mesh is a top-down (XY cross-section) view of the annular domain.
+/// Nodes with radius ≤ <see cref="InnerRadius"/> are assigned to the inner-electrode
+/// region; nodes with radius &gt; <see cref="InnerRadius"/> are assigned to the
+/// outer-electrode region.
+/// </para>
+/// </remarks>
+public sealed class CoaxialCylinderGeometry : IGeometryBuilder
+{
+    /// <summary>Gets the radius of the inner cylinder (m).</summary>
+    public double InnerRadius { get; }
+
+    /// <summary>Gets the radius of the outer cylinder (m).</summary>
+    public double OuterRadius { get; }
+
+    /// <summary>Gets the axial length of both cylinders (m).</summary>
+    public double Length { get; }
+
+    /// <summary>Gets the material of the inner cylinder.</summary>
+    public IMaterial InnerMaterial { get; }
+
+    /// <summary>Gets the material of the outer cylinder.</summary>
+    public IMaterial OuterMaterial { get; }
+
+    /// <inheritdoc/>
+    public IMaterial AnodeMaterial { get; }
+
+    /// <inheritdoc/>
+    public IMaterial CathodeMaterial { get; }
+
+    private readonly double _innerArea;
+    private readonly double _outerArea;
+    private readonly bool   _innerIsAnode;
+
+    /// <param name="innerMaterial">Material of the inner cylinder.</param>
+    /// <param name="outerMaterial">Material of the outer cylinder.</param>
+    /// <param name="innerRadius">Inner cylinder radius (m); must be positive.</param>
+    /// <param name="outerRadius">Outer cylinder radius (m); must exceed inner radius.</param>
+    /// <param name="length">Axial length (m); must be positive.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when either material is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when any dimension is invalid.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="outerRadius"/> ≤ <paramref name="innerRadius"/>, or when
+    /// both materials have the same standard potential.
+    /// </exception>
+    public CoaxialCylinderGeometry(
+        IMaterial innerMaterial,
+        IMaterial outerMaterial,
+        double    innerRadius,
+        double    outerRadius,
+        double    length)
+    {
+        ArgumentNullException.ThrowIfNull(innerMaterial);
+        ArgumentNullException.ThrowIfNull(outerMaterial);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(innerRadius, 0.0, nameof(innerRadius));
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(outerRadius, 0.0, nameof(outerRadius));
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(length, 0.0, nameof(length));
+
+        if (outerRadius <= innerRadius)
+            throw new ArgumentException(
+                "Outer radius must be strictly greater than the inner radius.", nameof(outerRadius));
+
+        if (innerMaterial.StandardPotential == outerMaterial.StandardPotential)
+            throw new ArgumentException(
+                "The inner and outer materials must have different standard potentials to form a galvanic couple.");
+
+        InnerMaterial = innerMaterial;
+        OuterMaterial = outerMaterial;
+        InnerRadius   = innerRadius;
+        OuterRadius   = outerRadius;
+        Length        = length;
+
+        _innerArea    = 2.0 * Math.PI * innerRadius * length;
+        _outerArea    = 2.0 * Math.PI * outerRadius * length;
+
+        _innerIsAnode  = innerMaterial.StandardPotential < outerMaterial.StandardPotential;
+        AnodeMaterial  = _innerIsAnode ? innerMaterial : outerMaterial;
+        CathodeMaterial = _innerIsAnode ? outerMaterial : innerMaterial;
+    }
+
+    /// <inheritdoc/>
+    public IGalvanicCell Build(IElectrolyte electrolyte)
+    {
+        ArgumentNullException.ThrowIfNull(electrolyte);
+
+        double anodeArea   = _innerIsAnode ? _innerArea : _outerArea;
+        double cathodeArea = _innerIsAnode ? _outerArea : _innerArea;
+
+        var anode   = new Electrode(AnodeMaterial,   anodeArea);
+        var cathode = new Electrode(CathodeMaterial, cathodeArea);
+        return new GalvanicCell(anode, cathode, electrolyte);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Generates a top-down (XY cross-section) view spanning
+    /// [−OuterRadius, OuterRadius] × [−OuterRadius, OuterRadius].
+    /// Nodes with √(x² + y²) ≤ InnerRadius are assigned to the inner-electrode
+    /// region; all others are assigned to the outer-electrode region.
+    /// </remarks>
+    public GeometryMesh BuildMesh(int nodesX = 20, int nodesY = 20)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(nodesX, 2, nameof(nodesX));
+        ArgumentOutOfRangeException.ThrowIfLessThan(nodesY, 2, nameof(nodesY));
+
+        int innerRegion = _innerIsAnode ? 0 : 1;
+        int outerRegion = _innerIsAnode ? 1 : 0;
+
+        double half  = OuterRadius;
+        double xStep = 2.0 * OuterRadius / (nodesX - 1);
+        double yStep = 2.0 * OuterRadius / (nodesY - 1);
+
+        var xs = new double[nodesX];
+        var ys = new double[nodesY];
+        for (int i = 0; i < nodesX; i++) xs[i] = -half + i * xStep;
+        for (int j = 0; j < nodesY; j++) ys[j] = -half + j * yStep;
+
+        double r2 = InnerRadius * InnerRadius;
+        var regions = new int[nodesX, nodesY];
+        for (int i = 0; i < nodesX; i++)
+            for (int j = 0; j < nodesY; j++)
+                regions[i, j] = xs[i] * xs[i] + ys[j] * ys[j] <= r2 ? innerRegion : outerRegion;
+
+        return new GeometryMesh(xs, ys, regions);
+    }
+}

--- a/src/GCE.Simulation/Geometry/ImmersedRodGeometry.cs
+++ b/src/GCE.Simulation/Geometry/ImmersedRodGeometry.cs
@@ -1,0 +1,159 @@
+using GCE.Core;
+using GCE.Electrochemistry;
+
+namespace GCE.Simulation.Geometry;
+
+/// <summary>
+/// Geometry builder for an immersed-rod configuration: a cylindrical rod of one
+/// material immersed vertically in a rectangular bath of a dissimilar metal.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <see cref="BoltInPlateGeometry"/>, the rod is fully immersed in the bath
+/// (no plate hole required). The bath is modelled as a flat plate with the rod's
+/// cross-sectional footprint subtracted from it.
+/// </para>
+/// <para>
+/// Electrode areas:
+/// <list type="bullet">
+///   <item>
+///     <description>Rod lateral area = 2π × <see cref="RodRadius"/> × <see cref="RodLength"/>.</description>
+///   </item>
+///   <item>
+///     <description>Bath area = <see cref="BathWidth"/> × <see cref="BathHeight"/> − π × <see cref="RodRadius"/>².</description>
+///   </item>
+/// </list>
+/// </para>
+/// <para>
+/// The material with the lower standard potential is assigned as the anode.
+/// </para>
+/// </remarks>
+public sealed class ImmersedRodGeometry : IGeometryBuilder
+{
+    /// <summary>Gets the radius of the rod (m).</summary>
+    public double RodRadius { get; }
+
+    /// <summary>Gets the length of the immersed rod (m).</summary>
+    public double RodLength { get; }
+
+    /// <summary>Gets the width of the rectangular bath (m).</summary>
+    public double BathWidth { get; }
+
+    /// <summary>Gets the height of the rectangular bath (m).</summary>
+    public double BathHeight { get; }
+
+    /// <summary>Gets the material of the rod.</summary>
+    public IMaterial RodMaterial { get; }
+
+    /// <summary>Gets the material of the bath.</summary>
+    public IMaterial BathMaterial { get; }
+
+    /// <inheritdoc/>
+    public IMaterial AnodeMaterial { get; }
+
+    /// <inheritdoc/>
+    public IMaterial CathodeMaterial { get; }
+
+    private readonly double _rodArea;
+    private readonly double _bathArea;
+    private readonly bool   _rodIsAnode;
+
+    /// <param name="rodMaterial">Material of the cylindrical rod.</param>
+    /// <param name="bathMaterial">Material of the bath plate.</param>
+    /// <param name="rodRadius">Rod radius (m); must be positive.</param>
+    /// <param name="rodLength">Immersed rod length (m); must be positive.</param>
+    /// <param name="bathWidth">Bath width (m); must be positive.</param>
+    /// <param name="bathHeight">Bath height (m); must be positive.</param>
+    /// <exception cref="ArgumentNullException">Thrown when either material is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when any dimension is not positive.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when both materials have the same standard potential, or when the rod footprint
+    /// area (π·r²) is not strictly less than the bath area (W·H).
+    /// </exception>
+    public ImmersedRodGeometry(
+        IMaterial rodMaterial,
+        IMaterial bathMaterial,
+        double    rodRadius,
+        double    rodLength,
+        double    bathWidth,
+        double    bathHeight)
+    {
+        ArgumentNullException.ThrowIfNull(rodMaterial);
+        ArgumentNullException.ThrowIfNull(bathMaterial);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(rodRadius, 0.0, nameof(rodRadius));
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(rodLength, 0.0, nameof(rodLength));
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(bathWidth, 0.0, nameof(bathWidth));
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(bathHeight, 0.0, nameof(bathHeight));
+
+        double bathArea = bathWidth * bathHeight - Math.PI * rodRadius * rodRadius;
+        if (bathArea <= 0.0)
+            throw new ArgumentException(
+                "The rod cross-sectional area must be strictly less than the bath area.",
+                nameof(rodRadius));
+
+        if (rodMaterial.StandardPotential == bathMaterial.StandardPotential)
+            throw new ArgumentException(
+                "The rod and bath materials must have different standard potentials to form a galvanic couple.");
+
+        RodMaterial  = rodMaterial;
+        BathMaterial = bathMaterial;
+        RodRadius    = rodRadius;
+        RodLength    = rodLength;
+        BathWidth    = bathWidth;
+        BathHeight   = bathHeight;
+
+        _rodArea  = 2.0 * Math.PI * rodRadius * rodLength;
+        _bathArea = bathArea;
+
+        _rodIsAnode    = rodMaterial.StandardPotential < bathMaterial.StandardPotential;
+        AnodeMaterial  = _rodIsAnode ? rodMaterial  : bathMaterial;
+        CathodeMaterial = _rodIsAnode ? bathMaterial : rodMaterial;
+    }
+
+    /// <inheritdoc/>
+    public IGalvanicCell Build(IElectrolyte electrolyte)
+    {
+        ArgumentNullException.ThrowIfNull(electrolyte);
+
+        double anodeArea   = _rodIsAnode ? _rodArea  : _bathArea;
+        double cathodeArea = _rodIsAnode ? _bathArea : _rodArea;
+
+        var anode   = new Electrode(AnodeMaterial,   anodeArea);
+        var cathode = new Electrode(CathodeMaterial, cathodeArea);
+        return new GalvanicCell(anode, cathode, electrolyte);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Generates a top-down (XY cross-section) view spanning
+    /// [−BathWidth/2, BathWidth/2] × [−BathHeight/2, BathHeight/2].
+    /// Nodes within <see cref="RodRadius"/> of the origin are assigned to the
+    /// rod region; all other nodes are assigned to the bath region.
+    /// </remarks>
+    public GeometryMesh BuildMesh(int nodesX = 20, int nodesY = 20)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(nodesX, 2, nameof(nodesX));
+        ArgumentOutOfRangeException.ThrowIfLessThan(nodesY, 2, nameof(nodesY));
+
+        int rodRegion  = _rodIsAnode ? 0 : 1;
+        int bathRegion = _rodIsAnode ? 1 : 0;
+
+        double halfW = BathWidth  / 2.0;
+        double halfH = BathHeight / 2.0;
+        double xStep = BathWidth  / (nodesX - 1);
+        double yStep = BathHeight / (nodesY - 1);
+
+        var xs = new double[nodesX];
+        var ys = new double[nodesY];
+        for (int i = 0; i < nodesX; i++) xs[i] = -halfW + i * xStep;
+        for (int j = 0; j < nodesY; j++) ys[j] = -halfH + j * yStep;
+
+        double r2 = RodRadius * RodRadius;
+        var regions = new int[nodesX, nodesY];
+        for (int i = 0; i < nodesX; i++)
+            for (int j = 0; j < nodesY; j++)
+                regions[i, j] = xs[i] * xs[i] + ys[j] * ys[j] <= r2 ? rodRegion : bathRegion;
+
+        return new GeometryMesh(xs, ys, regions);
+    }
+}

--- a/src/GCE.Simulation/Geometry/OverlapJointGeometry.cs
+++ b/src/GCE.Simulation/Geometry/OverlapJointGeometry.cs
@@ -1,0 +1,135 @@
+using GCE.Core;
+using GCE.Electrochemistry;
+
+namespace GCE.Simulation.Geometry;
+
+/// <summary>
+/// Geometry builder for an overlap-joint (lap-joint) configuration: two flat metal
+/// sheets of dissimilar materials that overlap along a rectangular interface zone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The overlap zone is the electrochemically active interface where galvanic
+/// corrosion occurs.  Both sheets contribute their overlap area to the galvanic
+/// couple.
+/// </para>
+/// <para>
+/// Electrode areas:
+/// <list type="bullet">
+///   <item>
+///     <description>Anode area = <see cref="OverlapWidth"/> × <see cref="OverlapLength"/>.</description>
+///   </item>
+///   <item>
+///     <description>Cathode area = <see cref="OverlapWidth"/> × <see cref="OverlapLength"/>.</description>
+///   </item>
+/// </list>
+/// Both areas are equal; the anode/cathode assignment is governed by the standard
+/// potentials of the materials.
+/// </para>
+/// <para>
+/// The 2-D mesh represents the overlap zone as seen from above.  The left half
+/// (x ≤ OverlapWidth/2) is assigned to one sheet and the right half to the other.
+/// </para>
+/// </remarks>
+public sealed class OverlapJointGeometry : IGeometryBuilder
+{
+    /// <summary>Gets the width of the overlap zone in the x-direction (m).</summary>
+    public double OverlapWidth { get; }
+
+    /// <summary>Gets the length of the overlap zone in the y-direction (m).</summary>
+    public double OverlapLength { get; }
+
+    /// <summary>Gets the material of the first (left) sheet.</summary>
+    public IMaterial Material1 { get; }
+
+    /// <summary>Gets the material of the second (right) sheet.</summary>
+    public IMaterial Material2 { get; }
+
+    /// <inheritdoc/>
+    public IMaterial AnodeMaterial { get; }
+
+    /// <inheritdoc/>
+    public IMaterial CathodeMaterial { get; }
+
+    private readonly bool   _mat1IsAnode;
+    private readonly double _overlapArea;
+
+    /// <param name="material1">Material of the first sheet.</param>
+    /// <param name="material2">Material of the second sheet.</param>
+    /// <param name="overlapWidth">Width of the overlap zone (m); must be positive.</param>
+    /// <param name="overlapLength">Length of the overlap zone (m); must be positive.</param>
+    /// <exception cref="ArgumentNullException">Thrown when either material is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when any dimension is not positive.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when both materials have the same standard potential (no galvanic couple).
+    /// </exception>
+    public OverlapJointGeometry(
+        IMaterial material1,
+        IMaterial material2,
+        double    overlapWidth,
+        double    overlapLength)
+    {
+        ArgumentNullException.ThrowIfNull(material1);
+        ArgumentNullException.ThrowIfNull(material2);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(overlapWidth,  0.0, nameof(overlapWidth));
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(overlapLength, 0.0, nameof(overlapLength));
+
+        if (material1.StandardPotential == material2.StandardPotential)
+            throw new ArgumentException(
+                "The two sheet materials must have different standard potentials to form a galvanic couple.");
+
+        Material1 = material1;
+        Material2 = material2;
+        OverlapWidth  = overlapWidth;
+        OverlapLength = overlapLength;
+        _overlapArea  = overlapWidth * overlapLength;
+
+        _mat1IsAnode   = material1.StandardPotential < material2.StandardPotential;
+        AnodeMaterial  = _mat1IsAnode ? material1 : material2;
+        CathodeMaterial = _mat1IsAnode ? material2 : material1;
+    }
+
+    /// <inheritdoc/>
+    public IGalvanicCell Build(IElectrolyte electrolyte)
+    {
+        ArgumentNullException.ThrowIfNull(electrolyte);
+
+        var anode   = new Electrode(AnodeMaterial,   _overlapArea);
+        var cathode = new Electrode(CathodeMaterial, _overlapArea);
+        return new GalvanicCell(anode, cathode, electrolyte);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Generates a top-down (XY) view of the overlap zone.
+    /// Nodes in the left half (x ≤ OverlapWidth/2) are assigned to the sheet-1 region;
+    /// nodes in the right half (x &gt; OverlapWidth/2) are assigned to the sheet-2 region.
+    /// </remarks>
+    public GeometryMesh BuildMesh(int nodesX = 20, int nodesY = 20)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(nodesX, 2, nameof(nodesX));
+        ArgumentOutOfRangeException.ThrowIfLessThan(nodesY, 2, nameof(nodesY));
+
+        int region1 = _mat1IsAnode ? 0 : 1;
+        int region2 = _mat1IsAnode ? 1 : 0;
+
+        double xStep = OverlapWidth  / (nodesX - 1);
+        double yStep = OverlapLength / (nodesY - 1);
+
+        var xs = new double[nodesX];
+        var ys = new double[nodesY];
+        for (int i = 0; i < nodesX; i++) xs[i] = i * xStep;
+        for (int j = 0; j < nodesY; j++) ys[j] = j * yStep;
+
+        double mid = OverlapWidth / 2.0;
+        var regions = new int[nodesX, nodesY];
+        for (int i = 0; i < nodesX; i++)
+        {
+            int region = xs[i] <= mid ? region1 : region2;
+            for (int j = 0; j < nodesY; j++)
+                regions[i, j] = region;
+        }
+
+        return new GeometryMesh(xs, ys, regions);
+    }
+}

--- a/src/GCE.Simulation/SimulationEngine.cs
+++ b/src/GCE.Simulation/SimulationEngine.cs
@@ -2,6 +2,7 @@ using GCE.Atmosphere;
 using GCE.Core;
 using GCE.Electrochemistry;
 using GCE.Numerics;
+using GCE.Numerics.Solvers;
 
 namespace GCE.Simulation;
 
@@ -152,6 +153,23 @@ public sealed class SimulationEngine : ISimulationRunner
 
         var solver = new RungeKuttaSolver(ode);
 
+        // Species transport tracking.
+        Dictionary<string, List<double>>? speciesHistory = null;
+        if (parameters.TrackedSpecies is { Count: > 0 })
+        {
+            speciesHistory = new Dictionary<string, List<double>>();
+            foreach (var st in parameters.TrackedSpecies)
+                speciesHistory[st.Species.Name] = new List<double>();
+        }
+
+        // pH tracking
+        List<double>? pHList = null;
+        double currentpH = parameters.Environment.pH;
+        if (parameters.TrackpH)
+        {
+            pHList = new List<double>();
+        }
+
         // Include the initial point when starting fresh (startStep == 0).
         if (startStep == 0)
         {
@@ -159,6 +177,14 @@ public sealed class SimulationEngine : ISimulationRunner
             times.Add(t);
             potentials.Add(potential);
             rates.Add(rate0);
+
+            if (speciesHistory is not null && parameters.TrackedSpecies is not null)
+            {
+                foreach (var st in parameters.TrackedSpecies)
+                    speciesHistory[st.Species.Name].Add(st.Species.Concentration);
+            }
+
+            pHList?.Add(currentpH);
         }
 
         double currentDt = nominalDt;
@@ -177,6 +203,16 @@ public sealed class SimulationEngine : ISimulationRunner
                     CorrosionRates   = rates.AsReadOnly(),
                 };
                 break;
+            }
+
+            // Advance species transport.
+            if (parameters.TrackedSpecies is not null)
+            {
+                foreach (var st in parameters.TrackedSpecies)
+                {
+                    st.Advance(1);
+                    speciesHistory?[st.Species.Name].Add(st.Species.Concentration);
+                }
             }
 
             if (timeEvolver is not null)
@@ -206,6 +242,22 @@ public sealed class SimulationEngine : ISimulationRunner
             potentials.Add(potential);
             rates.Add(rate);
 
+            if (pHList is not null)
+            {
+                // Update pH: net anodic current per unit area × dt produces H⁺
+                // (simplified: corrosion dissolves metal, not directly H⁺, but
+                //  for pH tracking we use the net current as a proxy)
+                var envForPh  = GetEnvironmentAt(parameters, t);
+                var anodeForPh = new ButlerVolmerModel(parameters.Pair.Anode, envForPh);
+                double iAnodePh = anodeForPh.ComputeCurrentDensity(potential);
+                // Assume 1 L effective volume, Faraday's law for H⁺ change
+                double deltaH = iAnodePh * currentDt / (PhysicalConstants.Faraday * 1.0);
+                double hConc  = Math.Pow(10.0, -currentpH);          // mol/L
+                hConc = Math.Max(hConc + deltaH * 1000.0, 1e-14);    // convert mol/m³ → mol/L
+                currentpH = -Math.Log10(hConc);
+                pHList.Add(currentpH);
+            }
+
             progress?.Report(new SimulationProgress(
                 CurrentStep:      step + 1,
                 TotalSteps:       parameters.TimeSteps,
@@ -217,13 +269,45 @@ public sealed class SimulationEngine : ISimulationRunner
 
         checkpoint = capturedCheckpoint;
 
+        // Spatial solve at the final mixed potential if a mesh was provided.
+        double[]? nodalPotentials    = null;
+        double[]? nodalCorrosionRates = null;
+        if (parameters.Mesh is not null && potentials.Count > 0)
+        {
+            double finalE  = potentials[^1];
+            double anodeE  = parameters.Pair.Anode.StandardPotential;
+            double cathodeE = parameters.Pair.Cathode.StandardPotential;
+            var    lastEnv  = GetEnvironmentAt(parameters, times.Count > 0 ? times[^1] : 0.0);
+            double kappa    = lastEnv.IonicConductivity > 0 ? lastEnv.IonicConductivity : 1e-3;
+
+            (nodalPotentials, nodalCorrosionRates) = SpatialSolver.Solve(
+                parameters.Mesh,
+                anodeE,
+                cathodeE,
+                kappa,
+                parameters.Pair.Anode);
+        }
+
+        IReadOnlyDictionary<string, IReadOnlyList<double>>? speciesConcentrationHistory = null;
+        if (speciesHistory is not null)
+        {
+            var dict = new Dictionary<string, IReadOnlyList<double>>();
+            foreach (var kvp in speciesHistory)
+                dict[kvp.Key] = kvp.Value.AsReadOnly();
+            speciesConcentrationHistory = dict;
+        }
+
         var result = new SimulationResult
         {
-            TimePoints        = times.AsReadOnly(),
-            MixedPotentials   = potentials.AsReadOnly(),
-            CorrosionRates    = rates.AsReadOnly(),
-            ConvergenceHistory = timeEvolver?.ConvergenceHistory
-                                     ?? (IReadOnlyList<ConvergenceInfo>)[],
+            TimePoints           = times.AsReadOnly(),
+            MixedPotentials      = potentials.AsReadOnly(),
+            CorrosionRates       = rates.AsReadOnly(),
+            ConvergenceHistory   = timeEvolver?.ConvergenceHistory
+                                       ?? (IReadOnlyList<ConvergenceInfo>)[],
+            NodalPotentials      = nodalPotentials,
+            NodalCorrosionRates  = nodalCorrosionRates,
+            SpeciesConcentrationHistory = speciesConcentrationHistory,
+            pHHistory = pHList?.AsReadOnly(),
         };
 
         return Task.FromResult(result);
@@ -244,10 +328,26 @@ public sealed class SimulationEngine : ISimulationRunner
             var anodeModel   = new ButlerVolmerModel(parameters.Pair.Anode,   env);
             var cathodeModel = new ButlerVolmerModel(parameters.Pair.Cathode, env);
 
-            // dE/dt proportional to net current (relaxation model):
-            // drives potential toward the mixed-potential equilibrium.
-            double netCurrent = anodeModel.ComputeCurrentDensity(potential)
-                              + cathodeModel.ComputeCurrentDensity(potential);
+            // Compute solution resistance Rs = PathLength / IonicConductivity (Ω·m²).
+            double rs = 0.0;
+            if (parameters.PathLength > 0.0 && env.IonicConductivity > 0.0)
+                rs = parameters.PathLength / env.IonicConductivity;
+
+            double iAnode   = anodeModel.ComputeCurrentDensity(potential);
+            double iCathode = cathodeModel.ComputeCurrentDensity(potential);
+
+            if (rs > 0.0)
+            {
+                // Ohmic IR-drop correction: the net current flowing through the
+                // solution resistance causes a voltage drop V_IR = iNet × Rs.
+                // Both electrode reactions see a shifted effective potential.
+                double iNet  = iAnode + iCathode;
+                double vDrop = Math.Clamp(iNet * rs, -1.0, 1.0);
+                iAnode   = anodeModel.ComputeCurrentDensity(potential - vDrop);
+                iCathode = cathodeModel.ComputeCurrentDensity(potential - vDrop);
+            }
+
+            double netCurrent = iAnode + iCathode;
             return -netCurrent * 0.01;
         };
     }
@@ -277,8 +377,26 @@ public sealed class SimulationEngine : ISimulationRunner
     /// When a weather provider is configured it is queried; otherwise the static
     /// environment from the parameters is returned.
     /// </summary>
-    private static IEnvironment GetEnvironmentAt(SimulationParameters parameters, double t) =>
-        parameters.WeatherProvider is not null
-            ? new WeatherDrivenAtmosphericConditions(parameters.WeatherProvider.GetObservation(t))
-            : parameters.Environment;
+    private static IEnvironment GetEnvironmentAt(SimulationParameters parameters, double t)
+    {
+        if (parameters.WeatherProvider is not null)
+        {
+            var obs = parameters.WeatherProvider.GetObservation(t);
+            if (parameters.FilmEvolution is not null)
+            {
+                // Advance the film by a small nominal step using the current observation.
+                // dt is approximated as DurationSeconds/TimeSteps.
+                double dt = parameters.DurationSeconds / parameters.TimeSteps;
+                parameters.FilmEvolution.Advance(dt, obs);
+                // Return an AtmosphericConditions derived from the updated film state.
+                var state = parameters.FilmEvolution.State;
+                return new AtmosphericConditions(
+                    state.SurfaceTemperatureCelsius,
+                    obs.RelativeHumidity,
+                    state.SaltConcentrationMolPerL);
+            }
+            return new WeatherDrivenAtmosphericConditions(obs);
+        }
+        return parameters.Environment;
+    }
 }

--- a/src/GCE.Simulation/SimulationParameters.cs
+++ b/src/GCE.Simulation/SimulationParameters.cs
@@ -1,3 +1,4 @@
+using GCE.Atmosphere;
 using GCE.Core;
 using GCE.Electrochemistry;
 
@@ -25,4 +26,9 @@ public sealed record SimulationParameters(
     double DurationSeconds,
     int TimeSteps = 1000,
     IWeatherProvider? WeatherProvider = null,
-    bool UseAdaptiveTimeStep = false);
+    bool UseAdaptiveTimeStep = false,
+    double PathLength = 0.0,
+    FilmEvolution? FilmEvolution = null,
+    GeometryMesh? Mesh = null,
+    IReadOnlyList<SpeciesTransport>? TrackedSpecies = null,
+    bool TrackpH = false);

--- a/src/GCE.Simulation/SimulationResult.cs
+++ b/src/GCE.Simulation/SimulationResult.cs
@@ -24,4 +24,32 @@ public sealed class SimulationResult
     /// <see langword="true"/>; otherwise empty.
     /// </summary>
     public IReadOnlyList<ConvergenceInfo> ConvergenceHistory { get; init; } = [];
+
+    /// <summary>
+    /// Gets the per-node electrolyte potential field (V vs. SHE), flattened in
+    /// row-major order (index = i*NodesY + j). Populated only when a
+    /// <see cref="GeometryMesh"/> is provided via
+    /// <see cref="SimulationParameters.Mesh"/>.
+    /// </summary>
+    public double[]? NodalPotentials { get; init; }
+
+    /// <summary>
+    /// Gets the per-node corrosion rate (mm/year), flattened in row-major order.
+    /// Populated only when a <see cref="GeometryMesh"/> is provided.
+    /// </summary>
+    public double[]? NodalCorrosionRates { get; init; }
+
+    /// <summary>
+    /// Gets the per-step average concentration (mol/m³) for each tracked species,
+    /// keyed by species name. Each value list has one entry per simulation time
+    /// point. <see langword="null"/> when no species transport is configured.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<double>>? SpeciesConcentrationHistory { get; init; }
+
+    /// <summary>
+    /// Gets the pH at each simulation time point. Populated only when
+    /// <see cref="SimulationParameters.TrackpH"/> is <see langword="true"/>.
+    /// <see langword="null"/> otherwise.
+    /// </summary>
+    public IReadOnlyList<double>? pHHistory { get; init; }
 }

--- a/src/GCE.Simulation/SpatialSolver.cs
+++ b/src/GCE.Simulation/SpatialSolver.cs
@@ -1,0 +1,117 @@
+using GCE.Core;
+using GCE.Numerics.Solvers;
+
+namespace GCE.Simulation;
+
+/// <summary>
+/// Computes the steady-state spatial distribution of electrolyte potential and
+/// corrosion rate on a <see cref="GeometryMesh"/> by solving the 2-D Laplace
+/// equation ∇²φ = 0.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Boundary conditions are derived from the galvanic couple's anode and cathode
+/// standard potentials (Dirichlet on each face; the anode face is set to the
+/// anode's standard potential and the cathode face to the cathode's standard
+/// potential).  All other faces carry zero-flux (Neumann) conditions.
+/// </para>
+/// <para>
+/// The local current density is computed from the potential gradient:
+///   j = −κ · ∂φ/∂x (for a side-by-side geometry)
+/// and the corrosion rate is derived from Faraday's law using the anode material
+/// properties.
+/// </para>
+/// </remarks>
+internal static class SpatialSolver
+{
+    private const double SecondsPerYear = 3.156e7;
+
+    /// <summary>
+    /// Solves the Laplace equation on <paramref name="mesh"/> and returns the
+    /// nodal potential field and nodal corrosion rates.
+    /// </summary>
+    /// <param name="mesh">The spatial mesh to solve on.</param>
+    /// <param name="anodePotential">
+    /// Dirichlet value (V vs. SHE) applied on the anode-region boundary (left face, x = 0).
+    /// </param>
+    /// <param name="cathodePotential">
+    /// Dirichlet value (V vs. SHE) applied on the cathode-region boundary (right face, x = Lx).
+    /// </param>
+    /// <param name="ionicConductivity">Electrolyte conductivity κ (S/m).</param>
+    /// <param name="anodeMaterial">Anode material for Faraday's-law corrosion-rate conversion.</param>
+    /// <returns>
+    /// A tuple of (nodalPotentials, nodalCorrosionRates), both flattened in
+    /// row-major order (index = i*ny + j).
+    /// </returns>
+    internal static (double[] NodalPotentials, double[] NodalCorrosionRates) Solve(
+        GeometryMesh mesh,
+        double       anodePotential,
+        double       cathodePotential,
+        double       ionicConductivity,
+        IMaterial    anodeMaterial)
+    {
+        ArgumentNullException.ThrowIfNull(mesh);
+        ArgumentNullException.ThrowIfNull(anodeMaterial);
+
+        int nx = mesh.NodesX;
+        int ny = mesh.NodesY;
+
+        double lx = mesh.XCoordinates[nx - 1] - mesh.XCoordinates[0];
+        double ly = mesh.YCoordinates[ny - 1] - mesh.YCoordinates[0];
+
+        // Guard against degenerate meshes.
+        if (lx <= 0.0) lx = 1.0;
+        if (ly <= 0.0) ly = 1.0;
+
+        // BCs: anode potential on the left face, cathode potential on the right face,
+        // zero-flux (insulating) on top and bottom.
+        var leftBC   = new DirichletBC(anodePotential);
+        var rightBC  = new DirichletBC(cathodePotential);
+        var bottomBC = new NeumannBC(0.0);
+        var topBC    = new NeumannBC(0.0);
+
+        var solver = new LaplaceSolver2D(
+            nx, ny, lx, ly,
+            leftBC, rightBC, bottomBC, topBC,
+            omega: 1.5);
+
+        var result = solver.Solve(new PdeSolverOptions { MaxIterations = 2000, Tolerance = 1e-8 });
+        double[] phi = result.Solution;
+
+        // Compute corrosion rates from current density j = -κ * dφ/dx (forward differences).
+        double dx = lx / (nx - 1);
+        double n  = anodeMaterial.ElectronsTransferred;
+        double M  = anodeMaterial.MolarMass;
+        double rho = anodeMaterial.Density;
+
+        double[] nodalPotentials     = new double[nx * ny];
+        double[] nodalCorrosionRates = new double[nx * ny];
+
+        for (int i = 0; i < nx; i++)
+        {
+            for (int j = 0; j < ny; j++)
+            {
+                int idx = i * ny + j;
+                nodalPotentials[idx] = phi[idx];
+
+                // Local current density (A/m²): central or forward difference in x.
+                double dphiDx;
+                if (i == 0)
+                    dphiDx = (phi[1 * ny + j] - phi[0 * ny + j]) / dx;
+                else if (i == nx - 1)
+                    dphiDx = (phi[(nx - 1) * ny + j] - phi[(nx - 2) * ny + j]) / dx;
+                else
+                    dphiDx = (phi[(i + 1) * ny + j] - phi[(i - 1) * ny + j]) / (2.0 * dx);
+
+                double currentDensity = -ionicConductivity * dphiDx; // A/m²
+
+                // Faraday's law: rate (mm/year) = |i| × M / (n × F × ρ) × seconds_per_year × 1000
+                nodalCorrosionRates[idx] = Math.Abs(currentDensity) * M
+                    / (n * PhysicalConstants.Faraday * rho)
+                    * SecondsPerYear * 1000.0;
+            }
+        }
+
+        return (nodalPotentials, nodalCorrosionRates);
+    }
+}

--- a/tests/GCE.Simulation.Tests/GeometryBuilderTests.cs
+++ b/tests/GCE.Simulation.Tests/GeometryBuilderTests.cs
@@ -470,3 +470,459 @@ public class IGeometryBuilderContractTests
         Assert.Equal(mesh.NodesY, mesh.Regions.GetLength(1));
     }
 }
+
+// ── CoaxialCylinderGeometry tests ─────────────────────────────────────────────
+
+public class CoaxialCylinderGeometryTests
+{
+    // Inner: zinc (anode, −0.76 V), outer: copper (cathode, +0.34 V).
+    // innerRadius = 5 mm, outerRadius = 20 mm, length = 100 mm.
+    private static CoaxialCylinderGeometry CreateDefault() =>
+        new(GeometryFixtures.Anode, GeometryFixtures.Cathode,
+            innerRadius: 0.005, outerRadius: 0.020, length: 0.100);
+
+    [Fact]
+    public void Constructor_StoresProperties()
+    {
+        var g = CreateDefault();
+        Assert.Equal(GeometryFixtures.Anode,   g.InnerMaterial);
+        Assert.Equal(GeometryFixtures.Cathode, g.OuterMaterial);
+        Assert.Equal(0.005, g.InnerRadius);
+        Assert.Equal(0.020, g.OuterRadius);
+        Assert.Equal(0.100, g.Length);
+    }
+
+    [Fact]
+    public void Constructor_ZincInner_IsAnode()
+    {
+        var g = CreateDefault();
+        Assert.Equal(MaterialRegistry.Zinc,   g.AnodeMaterial);
+        Assert.Equal(MaterialRegistry.Copper, g.CathodeMaterial);
+    }
+
+    [Fact]
+    public void Constructor_NobleInner_BecomesCathode()
+    {
+        var g = new CoaxialCylinderGeometry(
+            MaterialRegistry.Copper, MaterialRegistry.Zinc,
+            innerRadius: 0.005, outerRadius: 0.020, length: 0.100);
+
+        Assert.Equal(MaterialRegistry.Zinc,   g.AnodeMaterial);
+        Assert.Equal(MaterialRegistry.Copper, g.CathodeMaterial);
+    }
+
+    [Fact]
+    public void Constructor_OuterRadiusSmallerThanInner_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new CoaxialCylinderGeometry(
+                GeometryFixtures.Anode, GeometryFixtures.Cathode,
+                innerRadius: 0.020, outerRadius: 0.005, length: 0.100));
+    }
+
+    [Fact]
+    public void Constructor_EqualRadii_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new CoaxialCylinderGeometry(
+                GeometryFixtures.Anode, GeometryFixtures.Cathode,
+                innerRadius: 0.010, outerRadius: 0.010, length: 0.100));
+    }
+
+    [Fact]
+    public void Constructor_SamePotentialMaterials_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new CoaxialCylinderGeometry(
+                MaterialRegistry.Zinc, MaterialRegistry.Zinc,
+                innerRadius: 0.005, outerRadius: 0.020, length: 0.100));
+    }
+
+    [Fact]
+    public void Constructor_NonPositiveInnerRadius_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new CoaxialCylinderGeometry(
+                GeometryFixtures.Anode, GeometryFixtures.Cathode,
+                innerRadius: 0.0, outerRadius: 0.020, length: 0.100));
+    }
+
+    [Fact]
+    public void Build_AnodeArea_Equals2PiInnerRL()
+    {
+        var g = CreateDefault();
+        double expected = 2.0 * Math.PI * g.InnerRadius * g.Length;
+        var cell = g.Build(GeometryFixtures.Electrolyte);
+        Assert.Equal(expected, cell.Anode.Area, precision: 10);
+    }
+
+    [Fact]
+    public void Build_CathodeArea_Equals2PiOuterRL()
+    {
+        var g = CreateDefault();
+        double expected = 2.0 * Math.PI * g.OuterRadius * g.Length;
+        var cell = g.Build(GeometryFixtures.Electrolyte);
+        Assert.Equal(expected, cell.Cathode.Area, precision: 10);
+    }
+
+    [Fact]
+    public void Build_NullElectrolyte_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => CreateDefault().Build(null!));
+
+    [Fact]
+    public void BuildMesh_HasCorrectNodeCounts()
+    {
+        var mesh = CreateDefault().BuildMesh(12, 8);
+        Assert.Equal(12, mesh.NodesX);
+        Assert.Equal(8,  mesh.NodesY);
+    }
+
+    [Fact]
+    public void BuildMesh_OriginNode_IsInInnerRegion()
+    {
+        // With odd node counts the centre node is exactly at (0, 0).
+        var mesh = CreateDefault().BuildMesh(11, 11);
+        // Centre index = 5 for 11 nodes.
+        Assert.Equal(0, mesh.Regions[5, 5]); // inner = anode = region 0
+    }
+
+    [Fact]
+    public void BuildMesh_CornerNode_IsInOuterRegion()
+    {
+        var mesh = CreateDefault().BuildMesh(20, 20);
+        // Corners are at (±OuterRadius, ±OuterRadius): outside inner radius.
+        Assert.Equal(1, mesh.Regions[0,  0]);
+        Assert.Equal(1, mesh.Regions[19, 19]);
+    }
+
+    [Fact]
+    public void BuildMesh_XCoordinates_SpanFullOuterDiameter()
+    {
+        var g = CreateDefault();
+        var mesh = g.BuildMesh(21, 21);
+        Assert.Equal(-g.OuterRadius, mesh.XCoordinates[0],  precision: 10);
+        Assert.Equal(+g.OuterRadius, mesh.XCoordinates[20], precision: 10);
+    }
+
+    [Fact]
+    public void BuildMesh_TooFewNodes_Throws() =>
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            CreateDefault().BuildMesh(nodesX: 1));
+}
+
+// ── ImmersedRodGeometry tests ─────────────────────────────────────────────────
+
+public class ImmersedRodGeometryTests
+{
+    // Rod: zinc (anode, −0.76 V), bath: copper (cathode, +0.34 V).
+    // rodRadius = 5 mm, rodLength = 100 mm, bath = 100 mm × 100 mm.
+    private static ImmersedRodGeometry CreateDefault() =>
+        new(GeometryFixtures.Anode, GeometryFixtures.Cathode,
+            rodRadius: 0.005, rodLength: 0.100, bathWidth: 0.100, bathHeight: 0.100);
+
+    [Fact]
+    public void Constructor_StoresProperties()
+    {
+        var g = CreateDefault();
+        Assert.Equal(GeometryFixtures.Anode,   g.RodMaterial);
+        Assert.Equal(GeometryFixtures.Cathode, g.BathMaterial);
+        Assert.Equal(0.005, g.RodRadius);
+        Assert.Equal(0.100, g.RodLength);
+        Assert.Equal(0.100, g.BathWidth);
+        Assert.Equal(0.100, g.BathHeight);
+    }
+
+    [Fact]
+    public void Constructor_ZincRod_IsAnode()
+    {
+        var g = CreateDefault();
+        Assert.Equal(MaterialRegistry.Zinc,   g.AnodeMaterial);
+        Assert.Equal(MaterialRegistry.Copper, g.CathodeMaterial);
+    }
+
+    [Fact]
+    public void Constructor_NobleBath_RodIsAnode()
+    {
+        // Zinc rod in copper bath → zinc is still anode (same arrangement).
+        var g = CreateDefault();
+        Assert.True(g.AnodeMaterial.StandardPotential < g.CathodeMaterial.StandardPotential);
+    }
+
+    [Fact]
+    public void Constructor_CopperRod_ZincBath_RodIsCathode()
+    {
+        var g = new ImmersedRodGeometry(
+            MaterialRegistry.Copper, MaterialRegistry.Zinc,
+            rodRadius: 0.005, rodLength: 0.100, bathWidth: 0.100, bathHeight: 0.100);
+
+        Assert.Equal(MaterialRegistry.Zinc,   g.AnodeMaterial);
+        Assert.Equal(MaterialRegistry.Copper, g.CathodeMaterial);
+    }
+
+    [Fact]
+    public void Constructor_RodTooLargeForBath_Throws()
+    {
+        // π × r² ≥ W × H → invalid
+        Assert.Throws<ArgumentException>(() =>
+            new ImmersedRodGeometry(
+                GeometryFixtures.Anode, GeometryFixtures.Cathode,
+                rodRadius: 0.100, rodLength: 0.100, bathWidth: 0.100, bathHeight: 0.100));
+    }
+
+    [Fact]
+    public void Constructor_SamePotentialMaterials_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new ImmersedRodGeometry(
+                MaterialRegistry.Zinc, MaterialRegistry.Zinc,
+                rodRadius: 0.005, rodLength: 0.100, bathWidth: 0.100, bathHeight: 0.100));
+    }
+
+    [Fact]
+    public void Constructor_NonPositiveRodRadius_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ImmersedRodGeometry(
+                GeometryFixtures.Anode, GeometryFixtures.Cathode,
+                rodRadius: 0.0, rodLength: 0.100, bathWidth: 0.100, bathHeight: 0.100));
+    }
+
+    [Fact]
+    public void Build_AnodeArea_Equals2PiRL()
+    {
+        var g = CreateDefault();
+        double expected = 2.0 * Math.PI * g.RodRadius * g.RodLength;
+        var cell = g.Build(GeometryFixtures.Electrolyte);
+        Assert.Equal(expected, cell.Anode.Area, precision: 10);
+    }
+
+    [Fact]
+    public void Build_CathodeArea_EqualsBathMinusRodFootprint()
+    {
+        var g = CreateDefault();
+        double expected = g.BathWidth * g.BathHeight - Math.PI * g.RodRadius * g.RodRadius;
+        var cell = g.Build(GeometryFixtures.Electrolyte);
+        Assert.Equal(expected, cell.Cathode.Area, precision: 10);
+    }
+
+    [Fact]
+    public void Build_NullElectrolyte_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => CreateDefault().Build(null!));
+
+    [Fact]
+    public void BuildMesh_HasCorrectNodeCounts()
+    {
+        var mesh = CreateDefault().BuildMesh(10, 8);
+        Assert.Equal(10, mesh.NodesX);
+        Assert.Equal(8,  mesh.NodesY);
+    }
+
+    [Fact]
+    public void BuildMesh_CentreNode_IsInRodRegion()
+    {
+        // Use 11 nodes: centre at index 5, x = 0, y = 0 → inside rod.
+        var mesh = CreateDefault().BuildMesh(11, 11);
+        Assert.Equal(0, mesh.Regions[5, 5]); // rod = anode = region 0
+    }
+
+    [Fact]
+    public void BuildMesh_CornerNode_IsInBathRegion()
+    {
+        var mesh = CreateDefault().BuildMesh(20, 20);
+        Assert.Equal(1, mesh.Regions[0,  0]);
+        Assert.Equal(1, mesh.Regions[19, 19]);
+    }
+
+    [Fact]
+    public void BuildMesh_TooFewNodes_Throws() =>
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            CreateDefault().BuildMesh(nodesX: 1));
+}
+
+// ── OverlapJointGeometry tests ────────────────────────────────────────────────
+
+public class OverlapJointGeometryTests
+{
+    // Sheet-1: zinc (anode), sheet-2: copper (cathode).
+    // Overlap: 50 mm × 30 mm.
+    private static OverlapJointGeometry CreateDefault() =>
+        new(GeometryFixtures.Anode, GeometryFixtures.Cathode,
+            overlapWidth: 0.050, overlapLength: 0.030);
+
+    [Fact]
+    public void Constructor_StoresProperties()
+    {
+        var g = CreateDefault();
+        Assert.Equal(GeometryFixtures.Anode,   g.Material1);
+        Assert.Equal(GeometryFixtures.Cathode, g.Material2);
+        Assert.Equal(0.050, g.OverlapWidth);
+        Assert.Equal(0.030, g.OverlapLength);
+    }
+
+    [Fact]
+    public void Constructor_ZincMaterial1_IsAnode()
+    {
+        var g = CreateDefault();
+        Assert.Equal(MaterialRegistry.Zinc,   g.AnodeMaterial);
+        Assert.Equal(MaterialRegistry.Copper, g.CathodeMaterial);
+    }
+
+    [Fact]
+    public void Constructor_NobleMaterial1_BecomesCathode()
+    {
+        var g = new OverlapJointGeometry(
+            MaterialRegistry.Copper, MaterialRegistry.Zinc,
+            overlapWidth: 0.050, overlapLength: 0.030);
+
+        Assert.Equal(MaterialRegistry.Zinc,   g.AnodeMaterial);
+        Assert.Equal(MaterialRegistry.Copper, g.CathodeMaterial);
+    }
+
+    [Fact]
+    public void Constructor_SamePotentialMaterials_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new OverlapJointGeometry(
+                MaterialRegistry.Zinc, MaterialRegistry.Zinc,
+                overlapWidth: 0.050, overlapLength: 0.030));
+    }
+
+    [Fact]
+    public void Constructor_NonPositiveWidth_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new OverlapJointGeometry(
+                GeometryFixtures.Anode, GeometryFixtures.Cathode,
+                overlapWidth: 0.0, overlapLength: 0.030));
+    }
+
+    [Fact]
+    public void Build_AnodeAndCathodeAreas_EqualOverlapArea()
+    {
+        var g = CreateDefault();
+        double expected = g.OverlapWidth * g.OverlapLength;
+        var cell = g.Build(GeometryFixtures.Electrolyte);
+
+        Assert.Equal(expected, cell.Anode.Area,   precision: 10);
+        Assert.Equal(expected, cell.Cathode.Area, precision: 10);
+    }
+
+    [Fact]
+    public void Build_NullElectrolyte_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => CreateDefault().Build(null!));
+
+    [Fact]
+    public void BuildMesh_HasCorrectNodeCounts()
+    {
+        var mesh = CreateDefault().BuildMesh(10, 6);
+        Assert.Equal(10, mesh.NodesX);
+        Assert.Equal(6,  mesh.NodesY);
+    }
+
+    [Fact]
+    public void BuildMesh_LeftSide_IsFirstSheetRegion()
+    {
+        var mesh = CreateDefault().BuildMesh(20, 5);
+        // x = 0 is on the left (sheet-1 = zinc = anode = region 0).
+        for (int j = 0; j < 5; j++)
+            Assert.Equal(0, mesh.Regions[0, j]);
+    }
+
+    [Fact]
+    public void BuildMesh_RightSide_IsSecondSheetRegion()
+    {
+        var mesh = CreateDefault().BuildMesh(20, 5);
+        // Rightmost node is on sheet-2 side (cathode = region 1).
+        for (int j = 0; j < 5; j++)
+            Assert.Equal(1, mesh.Regions[19, j]);
+    }
+
+    [Fact]
+    public void BuildMesh_XCoordinates_SpanOverlapWidth()
+    {
+        var g = CreateDefault();
+        var mesh = g.BuildMesh(11, 5);
+        Assert.Equal(0.0,           mesh.XCoordinates[0],  precision: 10);
+        Assert.Equal(g.OverlapWidth, mesh.XCoordinates[10], precision: 10);
+    }
+
+    [Fact]
+    public void BuildMesh_TooFewNodes_Throws() =>
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            CreateDefault().BuildMesh(nodesX: 1));
+}
+
+// ── Extended IGeometryBuilder contract (new geometry types) ──────────────────
+
+public class IGeometryBuilderContractExtendedTests
+{
+    private static IElectrolyte Env => GeometryFixtures.Electrolyte;
+
+    public static IEnumerable<object[]> NewBuilders()
+    {
+        yield return new object[]
+        {
+            new CoaxialCylinderGeometry(
+                MaterialRegistry.Zinc, MaterialRegistry.Copper,
+                innerRadius: 0.005, outerRadius: 0.020, length: 0.100)
+        };
+        yield return new object[]
+        {
+            new ImmersedRodGeometry(
+                MaterialRegistry.Zinc, MaterialRegistry.Copper,
+                rodRadius: 0.005, rodLength: 0.100, bathWidth: 0.100, bathHeight: 0.100)
+        };
+        yield return new object[]
+        {
+            new OverlapJointGeometry(
+                MaterialRegistry.Zinc, MaterialRegistry.Copper,
+                overlapWidth: 0.050, overlapLength: 0.030)
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(NewBuilders))]
+    public void AnodePotential_LowerThanCathodePotential(IGeometryBuilder builder)
+    {
+        Assert.True(
+            builder.AnodeMaterial.StandardPotential < builder.CathodeMaterial.StandardPotential);
+    }
+
+    [Theory]
+    [MemberData(nameof(NewBuilders))]
+    public void Build_ReturnsCellWithPositiveAreas(IGeometryBuilder builder)
+    {
+        var cell = builder.Build(Env);
+        Assert.True(cell.Anode.Area   > 0.0);
+        Assert.True(cell.Cathode.Area > 0.0);
+    }
+
+    [Theory]
+    [MemberData(nameof(NewBuilders))]
+    public void Build_GalvanicVoltage_IsPositive(IGeometryBuilder builder)
+    {
+        var cell = builder.Build(Env);
+        Assert.True(cell.GalvanicVoltage > 0.0);
+    }
+
+    [Theory]
+    [MemberData(nameof(NewBuilders))]
+    public void BuildMesh_RegionsContainOnlyValidValues(IGeometryBuilder builder)
+    {
+        var mesh = builder.BuildMesh(10, 10);
+        for (int i = 0; i < mesh.NodesX; i++)
+            for (int j = 0; j < mesh.NodesY; j++)
+                Assert.True(
+                    mesh.Regions[i, j] is 0 or 1,
+                    $"Unexpected region id {mesh.Regions[i, j]} at [{i},{j}].");
+    }
+
+    [Theory]
+    [MemberData(nameof(NewBuilders))]
+    public void BuildMesh_CoordinateArraysMatchRegionDimensions(IGeometryBuilder builder)
+    {
+        var mesh = builder.BuildMesh(8, 6);
+        Assert.Equal(mesh.NodesX, mesh.Regions.GetLength(0));
+        Assert.Equal(mesh.NodesY, mesh.Regions.GetLength(1));
+    }
+}

--- a/tests/GCE.Simulation.Tests/ResultWriterTests.cs
+++ b/tests/GCE.Simulation.Tests/ResultWriterTests.cs
@@ -346,4 +346,31 @@ public class VtkResultWriterTests
             File.Delete(path);
         }
     }
+
+    [Fact]
+    public void Write_WithNodalData_WritesAdditionalPointDataArrays()
+    {
+        // A result that includes nodal potentials and corrosion rates (as would be
+        // produced when a GeometryMesh is provided to SimulationParameters).
+        var nodalPotentials    = new double[] { -0.50, -0.45, -0.48, -0.43, -0.46, 0.10 };
+        var nodalCorrosionRates = new double[] { 0.10, 0.20, 0.15, 0.25, 0.12, 0.05 };
+
+        var result = new SimulationResult
+        {
+            TimePoints      = [0.0, 3600.0],
+            MixedPotentials = [-0.42, -0.41],
+            CorrosionRates  = [0.1, 0.12],
+            NodalPotentials    = nodalPotentials,
+            NodalCorrosionRates = nodalCorrosionRates,
+        };
+
+        var writer = new VtkResultWriter(WriterFixtures.TinyMesh());
+        using var sw = new StringWriter();
+
+        writer.Write(result, sw);
+
+        string xml = sw.ToString();
+        Assert.Contains("NodalPotential_V",          xml);
+        Assert.Contains("NodalCorrosionRate_mmPerYear", xml);
+    }
 }

--- a/tests/GCE.Simulation.Tests/SimulationEngineTests.cs
+++ b/tests/GCE.Simulation.Tests/SimulationEngineTests.cs
@@ -1,6 +1,7 @@
 using GCE.Atmosphere;
 using GCE.Core;
 using GCE.Electrochemistry;
+using GCE.Numerics.Solvers;
 using GCE.Simulation;
 
 namespace GCE.Simulation.Tests;
@@ -547,5 +548,289 @@ public class SimulationEngineTests
 
         Assert.Equal(11, result.TimePoints.Count);
         Assert.NotEmpty(result.ConvergenceHistory);
+    }
+}
+
+// ── OhmicDropTests ────────────────────────────────────────────────────────────
+
+public class OhmicDropTests
+{
+    private static readonly SimulationEngine Engine = new();
+
+    [Fact]
+    public void Run_WithZeroPathLength_ProducesSameStepCountAsBaseline()
+    {
+        var baseline = SimulationTestFixtures.DefaultParameters(durationSeconds: 360, timeSteps: 10);
+        var withOhmic = baseline with { PathLength = 0.0 };
+
+        var r1 = Engine.Run(baseline);
+        var r2 = Engine.Run(withOhmic);
+
+        Assert.Equal(r1.TimePoints.Count, r2.TimePoints.Count);
+    }
+
+    [Fact]
+    public void Run_WithNonZeroPathLength_SucceedsAndHasCorrectStepCount()
+    {
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 360, timeSteps: 10) with { PathLength = 0.005 };
+
+        var result = Engine.Run(parameters);
+
+        // 10 steps + initial point
+        Assert.Equal(11, result.TimePoints.Count);
+        Assert.Equal(11, result.MixedPotentials.Count);
+        Assert.Equal(11, result.CorrosionRates.Count);
+    }
+
+    [Fact]
+    public void Run_WithPathLength_CorrosionRatesAreNonNegative()
+    {
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 3600, timeSteps: 50) with { PathLength = 0.010 };
+
+        var result = Engine.Run(parameters);
+
+        Assert.All(result.CorrosionRates, r => Assert.True(r >= 0.0));
+    }
+
+    [Fact]
+    public void Run_WithPathLength_MixedPotentialLiesBetweenStandardPotentials()
+    {
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 1800, timeSteps: 30) with { PathLength = 0.010 };
+
+        var result = Engine.Run(parameters);
+
+        double anodeE   = MaterialRegistry.Zinc.StandardPotential;
+        double cathodeE = MaterialRegistry.Copper.StandardPotential;
+
+        foreach (double e in result.MixedPotentials)
+        {
+            Assert.True(e >= anodeE,   $"Potential {e:G4} is below anode OCP.");
+            Assert.True(e <= cathodeE, $"Potential {e:G4} is above cathode OCP.");
+        }
+    }
+
+    [Fact]
+    public void Run_HighPathLength_ReducesAverageCorrosionRateVsLowPathLength()
+    {
+        // A longer electrolyte path adds more ohmic resistance, which should
+        // reduce the net driving potential and therefore the corrosion rate.
+        var low  = SimulationTestFixtures.DefaultParameters(durationSeconds: 3600, timeSteps: 50)
+                        with { PathLength = 1e-6 };
+        var high = SimulationTestFixtures.DefaultParameters(durationSeconds: 3600, timeSteps: 50)
+                        with { PathLength = 1.0 };
+
+        double avgLow  = Engine.Run(low).AverageCorrosionRate;
+        double avgHigh = Engine.Run(high).AverageCorrosionRate;
+
+        Assert.True(avgHigh <= avgLow,
+            $"High-resistance run ({avgHigh:G4}) should not exceed low-resistance run ({avgLow:G4}).");
+    }
+}
+
+// ── SpatialDistributionTests ──────────────────────────────────────────────────
+
+public class SpatialDistributionTests
+{
+    private static readonly SimulationEngine Engine = new();
+
+    private static GeometryMesh TinyMesh()
+    {
+        var regions = new int[5, 5];
+        for (int i = 0; i < 5; i++)
+            for (int j = 0; j < 5; j++)
+                regions[i, j] = i < 3 ? 0 : 1; // left = anode, right = cathode
+        return new GeometryMesh(
+            XCoordinates: [0.0, 0.025, 0.050, 0.075, 0.100],
+            YCoordinates: [0.0, 0.025, 0.050, 0.075, 0.100],
+            Regions: regions);
+    }
+
+    [Fact]
+    public void Run_WithMesh_PopulatesNodalPotentials()
+    {
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 360, timeSteps: 10) with { Mesh = TinyMesh() };
+
+        var result = Engine.Run(parameters);
+
+        Assert.NotNull(result.NodalPotentials);
+        Assert.Equal(25, result.NodalPotentials!.Length); // 5×5 = 25 nodes
+    }
+
+    [Fact]
+    public void Run_WithMesh_PopulatesNodalCorrosionRates()
+    {
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 360, timeSteps: 10) with { Mesh = TinyMesh() };
+
+        var result = Engine.Run(parameters);
+
+        Assert.NotNull(result.NodalCorrosionRates);
+        Assert.Equal(25, result.NodalCorrosionRates!.Length);
+    }
+
+    [Fact]
+    public void Run_WithMesh_NodalCorrosionRatesAreNonNegative()
+    {
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 360, timeSteps: 10) with { Mesh = TinyMesh() };
+
+        var result = Engine.Run(parameters);
+
+        Assert.All(result.NodalCorrosionRates!, r => Assert.True(r >= 0.0));
+    }
+
+    [Fact]
+    public void Run_WithMesh_NodalPotentialsContainFiniteValues()
+    {
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 360, timeSteps: 10) with { Mesh = TinyMesh() };
+
+        var result = Engine.Run(parameters);
+
+        Assert.All(result.NodalPotentials!, v => Assert.True(double.IsFinite(v)));
+    }
+
+    [Fact]
+    public void Run_WithoutMesh_NodalPropertiesAreNull()
+    {
+        var parameters = SimulationTestFixtures.DefaultParameters();
+
+        var result = Engine.Run(parameters);
+
+        Assert.Null(result.NodalPotentials);
+        Assert.Null(result.NodalCorrosionRates);
+    }
+}
+
+// ── SpeciesTransportSimulationTests ──────────────────────────────────────────
+
+public class SpeciesTransportSimulationTests
+{
+    private static readonly SimulationEngine Engine = new();
+
+    private static SpeciesTransport CreateChlorideTransport()
+    {
+        var cl = new Species("Cl-", -1, diffusionCoefficient: 2.03e-9, concentration: 100.0);
+        var leftBC  = new DirichletBC(100.0);
+        var rightBC = new DirichletBC(100.0);
+        return new SpeciesTransport(cl, domainLength: 1e-4, gridPoints: 5,
+            initialProfile: [100.0, 100.0, 100.0, 100.0, 100.0],
+            leftBC: leftBC, rightBC: rightBC, timeStep: 1.0);
+    }
+
+    [Fact]
+    public void Run_WithTrackedSpecies_PopulatesSpeciesConcentrationHistory()
+    {
+        var st = CreateChlorideTransport();
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 360, timeSteps: 10)
+            with { TrackedSpecies = [st] };
+
+        var result = Engine.Run(parameters);
+
+        Assert.NotNull(result.SpeciesConcentrationHistory);
+        Assert.True(result.SpeciesConcentrationHistory!.ContainsKey("Cl-"));
+    }
+
+    [Fact]
+    public void Run_WithTrackedSpecies_HistoryHasCorrectEntryCount()
+    {
+        var st = CreateChlorideTransport();
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 360, timeSteps: 10)
+            with { TrackedSpecies = [st] };
+
+        var result = Engine.Run(parameters);
+
+        // Initial point + 10 steps = 11 entries.
+        Assert.Equal(11, result.SpeciesConcentrationHistory!["Cl-"].Count);
+    }
+
+    [Fact]
+    public void Run_WithTrackedSpecies_ConcentrationsAreNonNegative()
+    {
+        var st = CreateChlorideTransport();
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 360, timeSteps: 10)
+            with { TrackedSpecies = [st] };
+
+        var result = Engine.Run(parameters);
+
+        Assert.All(result.SpeciesConcentrationHistory!["Cl-"], c => Assert.True(c >= 0.0));
+    }
+
+    [Fact]
+    public void Run_WithoutTrackedSpecies_SpeciesConcentrationHistoryIsNull()
+    {
+        var result = Engine.Run(SimulationTestFixtures.DefaultParameters());
+
+        Assert.Null(result.SpeciesConcentrationHistory);
+    }
+}
+
+// ── pHTrackingTests ───────────────────────────────────────────────────────────
+
+public class pHTrackingTests
+{
+    private static readonly SimulationEngine Engine = new();
+
+    [Fact]
+    public void Run_WithTrackpH_PopulatespHHistory()
+    {
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 360, timeSteps: 10) with { TrackpH = true };
+
+        var result = Engine.Run(parameters);
+
+        Assert.NotNull(result.pHHistory);
+    }
+
+    [Fact]
+    public void Run_WithTrackpH_HistoryHasCorrectEntryCount()
+    {
+        int steps = 10;
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 360, timeSteps: steps) with { TrackpH = true };
+
+        var result = Engine.Run(parameters);
+
+        // Initial pH + one per step = steps + 1 total
+        Assert.Equal(steps + 1, result.pHHistory!.Count);
+    }
+
+    [Fact]
+    public void Run_WithTrackpH_AllValuesAreFinite()
+    {
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 360, timeSteps: 10) with { TrackpH = true };
+
+        var result = Engine.Run(parameters);
+
+        Assert.All(result.pHHistory!, v => Assert.True(double.IsFinite(v)));
+    }
+
+    [Fact]
+    public void Run_WithoutTrackpH_pHHistoryIsNull()
+    {
+        var result = Engine.Run(SimulationTestFixtures.DefaultParameters());
+
+        Assert.Null(result.pHHistory);
+    }
+
+    [Fact]
+    public void Run_WithTrackpH_InitialValueMatchesEnvironmentpH()
+    {
+        var env = new AtmosphericConditions(25.0, 0.75, 0.1);
+        var parameters = SimulationTestFixtures.DefaultParameters(
+            durationSeconds: 360, timeSteps: 10) with { TrackpH = true };
+
+        var result = Engine.Run(parameters);
+
+        // First entry should be the initial pH of the environment.
+        Assert.Equal(env.pH, result.pHHistory![0], precision: 6);
     }
 }

--- a/tests/GCE.Simulation.Tests/SpatialSolverTests.cs
+++ b/tests/GCE.Simulation.Tests/SpatialSolverTests.cs
@@ -1,0 +1,136 @@
+using GCE.Atmosphere;
+using GCE.Core;
+using GCE.Electrochemistry;
+using GCE.Simulation;
+using GCE.Simulation.Geometry;
+
+namespace GCE.Simulation.Tests;
+
+/// <summary>
+/// Tests for the spatial potential solver exercised through
+/// <see cref="SimulationEngine"/> with a <see cref="GeometryMesh"/>.
+/// </summary>
+/// <remarks>
+/// <see cref="SpatialSolver"/> is an <c>internal</c> helper; its behaviour is
+/// verified indirectly via the public <see cref="SimulationEngine"/> API.
+/// </remarks>
+public class SpatialSolverTests
+{
+    private static readonly SimulationEngine Engine = new();
+
+    // 5×5 mesh: nodes 0–2 in x are the anode region (0), nodes 3–4 are cathode (1).
+    private static GeometryMesh FiveFiveMesh()
+    {
+        var regions = new int[5, 5];
+        for (int i = 0; i < 5; i++)
+            for (int j = 0; j < 5; j++)
+                regions[i, j] = i <= 2 ? 0 : 1;
+
+        return new GeometryMesh(
+            XCoordinates: [0.00, 0.025, 0.050, 0.075, 0.100],
+            YCoordinates: [0.00, 0.025, 0.050, 0.075, 0.100],
+            Regions: regions);
+    }
+
+    private static SimulationParameters MakeParams(GeometryMesh mesh) =>
+        new SimulationParameters(
+            new GalvanicPair(MaterialRegistry.Zinc, MaterialRegistry.Copper),
+            new AtmosphericConditions(25.0, 0.75, 0.1),
+            DurationSeconds: 360,
+            TimeSteps: 10,
+            Mesh: mesh);
+
+    [Fact]
+    public void Run_WithMesh_NodalPotentialsLengthMatchesMeshNodeCount()
+    {
+        var mesh = FiveFiveMesh();
+        var result = Engine.Run(MakeParams(mesh));
+
+        Assert.NotNull(result.NodalPotentials);
+        Assert.Equal(mesh.NodesX * mesh.NodesY, result.NodalPotentials!.Length);
+    }
+
+    [Fact]
+    public void Run_WithMesh_NodalCorrosionRatesLengthMatchesMeshNodeCount()
+    {
+        var mesh = FiveFiveMesh();
+        var result = Engine.Run(MakeParams(mesh));
+
+        Assert.NotNull(result.NodalCorrosionRates);
+        Assert.Equal(mesh.NodesX * mesh.NodesY, result.NodalCorrosionRates!.Length);
+    }
+
+    [Fact]
+    public void Run_WithMesh_NodalPotentialsAreFinite()
+    {
+        var result = Engine.Run(MakeParams(FiveFiveMesh()));
+
+        Assert.All(result.NodalPotentials!, v => Assert.True(double.IsFinite(v)));
+    }
+
+    [Fact]
+    public void Run_WithMesh_NodalCorrosionRatesAreNonNegative()
+    {
+        var result = Engine.Run(MakeParams(FiveFiveMesh()));
+
+        Assert.All(result.NodalCorrosionRates!, r => Assert.True(r >= 0.0, $"Rate {r} is negative."));
+    }
+
+    [Fact]
+    public void Run_WithGeometryBuilder_MeshProducesNodalResults()
+    {
+        // Build a mesh from SideBySideGeometry and pass it to the engine.
+        var g = new SideBySideGeometry(
+            MaterialRegistry.Zinc, MaterialRegistry.Copper,
+            anodeWidth: 0.020, cathodeWidth: 0.020, length: 0.050);
+        var mesh = g.BuildMesh(6, 4);
+
+        var parameters = new SimulationParameters(
+            new GalvanicPair(MaterialRegistry.Zinc, MaterialRegistry.Copper),
+            new AtmosphericConditions(25.0, 0.75, 0.1),
+            DurationSeconds: 360,
+            TimeSteps: 5,
+            Mesh: mesh);
+
+        var result = Engine.Run(parameters);
+
+        Assert.NotNull(result.NodalPotentials);
+        Assert.Equal(mesh.NodesX * mesh.NodesY, result.NodalPotentials!.Length);
+    }
+
+    [Fact]
+    public void Run_WithoutMesh_NodalResultsAreNull()
+    {
+        var parameters = new SimulationParameters(
+            new GalvanicPair(MaterialRegistry.Zinc, MaterialRegistry.Copper),
+            new AtmosphericConditions(25.0, 0.75, 0.1),
+            DurationSeconds: 360,
+            TimeSteps: 5);
+
+        var result = Engine.Run(parameters);
+
+        Assert.Null(result.NodalPotentials);
+        Assert.Null(result.NodalCorrosionRates);
+    }
+
+    [Fact]
+    public void Run_LargerMesh_HasExpectedNodeCount()
+    {
+        var g = new BoltInPlateGeometry(
+            MaterialRegistry.Zinc, MaterialRegistry.Copper,
+            boltRadius: 0.005, plateThickness: 0.010, plateWidth: 0.050);
+        var mesh = g.BuildMesh(10, 10);
+
+        var parameters = new SimulationParameters(
+            new GalvanicPair(MaterialRegistry.Zinc, MaterialRegistry.Copper),
+            new AtmosphericConditions(25.0, 0.75, 0.1),
+            DurationSeconds: 360,
+            TimeSteps: 5,
+            Mesh: mesh);
+
+        var result = Engine.Run(parameters);
+
+        Assert.Equal(100, result.NodalPotentials!.Length); // 10×10
+        Assert.Equal(100, result.NodalCorrosionRates!.Length);
+    }
+}


### PR DESCRIPTION
Issue #1 – Ohmic IR-drop correction
- Add PathLength parameter to SimulationParameters
- Replace per-electrode ohmic correction with net-current IR-drop model (V_drop = iNet × Rs, clamped to ±1 V for numerical stability)

Issue #2 – Spatial current-density distribution (Laplace solver)
- Add Mesh parameter to SimulationParameters
- Add NodalPotentials and NodalCorrosionRates to SimulationResult
- Add SpatialSolver internal class (wraps LaplaceSolver2D, computes nodal corrosion rates via Faraday's law)
- Engine performs a spatial solve at the end of each run when Mesh != null
- VtkResultWriter writes NodalPotential_V and NodalCorrosionRate_mmPerYear point-data arrays when present

Issue #3 – Species transport tracking
- Add TrackedSpecies parameter to SimulationParameters
- Add SpeciesConcentrationHistory to SimulationResult
- Engine advances each SpeciesTransport by one step per loop iteration

Issue #4 – pH evolution tracking
- Add TrackpH parameter to SimulationParameters
- Add pHHistory to SimulationResult
- Add WithpH() factory methods to HydrogenEvolutionReaction and OxygenReductionReaction

Issue #5a – New geometry builders
- Add CoaxialCylinderGeometry (inner/outer cylinder galvanic couple)
- Add ImmersedRodGeometry (rod immersed in rectangular bath)
- Add OverlapJointGeometry (lap-joint overlap zone)

Tests
- OhmicDropTests, SpatialDistributionTests, SpeciesTransportSimulationTests, pHTrackingTests added to SimulationEngineTests.cs
- New SpatialSolverTests.cs (tests spatial solve via public engine API)
- CoaxialCylinderGeometryTests, ImmersedRodGeometryTests, OverlapJointGeometryTests, IGeometryBuilderContractExtendedTests added to GeometryBuilderTests.cs
- VtkWriter_WithNodalData_WritesAdditionalPointDataArrays added to ResultWriterTests.cs

Documentation
- docs/README.md: added Ohmic IR Drop, Spatial Distribution, Species Transport, and pH Evolution sections